### PR TITLE
Update db connection

### DIFF
--- a/deploy-uaa-pre-steps.sh
+++ b/deploy-uaa-pre-steps.sh
@@ -23,9 +23,9 @@ sed -i -- "s/DB_PASSWORD/${DB_PASSWORD}/g" uaa-cf-application.yml
 sed -i -- "s|PRIVATE_KEY_PASSWORD|${UAA_PRIVATE_KEY_PASSWORD}|g" uaa-cf-application.yml
 sed -i -- "s|UAA_ID|$UAA_ID|g" uaa-cf-application.yml
 sed -i -- "s|UAA_SECRET|$UAA_SECRET|g" uaa-cf-application.yml
-sed -i -- "s|UAA-URL|$UAA-URL|g" uaa-cf-application.yml
-sed -i -- "s|LOGIN-URL|$LOGIN-URL|g" uaa-cf-application.yml
-sed -i -- "s|ZONE-URL|$ZONE-URL|g" uaa-cf-application.yml
+sed -i -- "s|UAA-URL|$UAA_URL|g" uaa-cf-application.yml
+sed -i -- "s|LOGIN-URL|$LOGIN_URL|g" uaa-cf-application.yml
+sed -i -- "s|ZONE-URL|$ZONE_URL|g" uaa-cf-application.yml
 
 echo "$UAA_PRIVATE_KEY" > private_key
 echo "$UAA_CERTIFICATE" > certificate

--- a/deploy-uaa-pre-steps.sh
+++ b/deploy-uaa-pre-steps.sh
@@ -23,6 +23,9 @@ sed -i -- "s/DB_PASSWORD/${DB_PASSWORD}/g" uaa-cf-application.yml
 sed -i -- "s|PRIVATE_KEY_PASSWORD|${UAA_PRIVATE_KEY_PASSWORD}|g" uaa-cf-application.yml
 sed -i -- "s|UAA_ID|$UAA_ID|g" uaa-cf-application.yml
 sed -i -- "s|UAA_SECRET|$UAA_SECRET|g" uaa-cf-application.yml
+sed -i -- "s|UAA-URL|$UAA-URL|g" uaa-cf-application.yml
+sed -i -- "s|LOGIN-URL|$LOGIN-URL|g" uaa-cf-application.yml
+sed -i -- "s|ZONE-URL|$ZONE-URL|g" uaa-cf-application.yml
 
 echo "$UAA_PRIVATE_KEY" > private_key
 echo "$UAA_CERTIFICATE" > certificate

--- a/src/main/resources/uaa-cf-application.yml
+++ b/src/main/resources/uaa-cf-application.yml
@@ -13,8 +13,8 @@ applications:
   scope: none
   authorities: uaa.admin,clients.read,clients.write,clients.secret
   env:
-    UAA_URL: http://uaa-SPACE.apps.devtest.onsclofo.uk
-    LOGIN_URL: http://uaa-SPACE.apps.devtest.onsclofo.uk
+    UAA_URL: UAA-URL
+    LOGIN_URL: LOGIN-URL
     JBP_CONFIG_SPRING_AUTO_RECONFIGURATION: '{enabled: false}'
     UAA_CONFIG_YAML: |
       spring_profiles: default,postgresql
@@ -41,4 +41,4 @@ applications:
       zones:
          internal:
            hostnames:
-             - uaa-SPACE.apps.devtest.onsclofo.uk
+             - ZONE-URL


### PR DESCRIPTION
Update the way in which the DB connection is set in pre-steps.sh.  If in dev mode (and a 'dev' flag is passed) then a new rds service is created and the DB details are derived from the service key.  In (pre)prod, the DB is permanent and the connection details come directly from the Jenkins job.