### PR TITLE
Pin to pip version 18.0

### DIFF
--- a/scripts/jenkins/add_client.sh
+++ b/scripts/jenkins/add_client.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pipenv run pip install pip==18.0
 pipenv install requests
 
 # Create a client for RAS backstage

--- a/scripts/jenkins/add_group.sh
+++ b/scripts/jenkins/add_group.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pipenv run pip install pip==18.0
 pipenv install requests
 
 pipenv run python ./scripts/create_group.py -ci login -cs $LOGIN_SECRET -url $UAA_URL -g surveys.$GROUP_ID -d $GROUP_NAME -v

--- a/scripts/jenkins/add_user.sh
+++ b/scripts/jenkins/add_user.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pipenv run pip install pip==18.0
 pipenv install requests
 
 # Create Users

--- a/scripts/jenkins/add_user_to_group.sh
+++ b/scripts/jenkins/add_user_to_group.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pipenv run pip install pip==18.0
 pipenv install requests
 
 pipenv run python ./scripts/add_user_to_group.py -ci admin -cs $ADMIN_SECRET -url $UAA_URL -g surveys.$GROUP_ID -u $USERNAME -v

--- a/scripts/jenkins/change_password.sh
+++ b/scripts/jenkins/change_password.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pipenv run pip install pip==18.0
 pipenv install requests
 
 # Create Users

--- a/scripts/jenkins/change_secret.sh
+++ b/scripts/jenkins/change_secret.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pipenv run pip install pip==18.0
 pipenv install requests
 
 # Create Users


### PR DESCRIPTION
Pip 18.1 causes "TypeError: 'module' object is not callable"
with pipenv. This Pr just pins the pip version to the previous
working version 18.0 for all the scripts.