### PR TITLE
Pin to pip version 18.0

### DIFF
--- a/scripts/jenkins/add_client.sh
+++ b/scripts/jenkins/add_client.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pip install --upgrade pip==18.0
 pipenv run pip install pip==18.0
 pipenv install requests
 

--- a/scripts/jenkins/add_group.sh
+++ b/scripts/jenkins/add_group.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pip install --upgrade pip==18.0
 pipenv run pip install pip==18.0
 pipenv install requests
 

--- a/scripts/jenkins/add_user.sh
+++ b/scripts/jenkins/add_user.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pip install --upgrade pip==18.0
 pipenv run pip install pip==18.0
 pipenv install requests
 

--- a/scripts/jenkins/add_user_to_group.sh
+++ b/scripts/jenkins/add_user_to_group.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pip install --upgrade pip==18.0
 pipenv run pip install pip==18.0
 pipenv install requests
 

--- a/scripts/jenkins/change_password.sh
+++ b/scripts/jenkins/change_password.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pip install --upgrade pip==18.0
 pipenv run pip install pip==18.0
 pipenv install requests
 

--- a/scripts/jenkins/change_secret.sh
+++ b/scripts/jenkins/change_secret.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pip install --upgrade pip==18.0
 pipenv run pip install pip==18.0
 pipenv install requests
 


### PR DESCRIPTION
Pip 18.1 causes "TypeError: 'module' object is not callable"
with pipenv. This Pr pins the outher pip version to the previous
working version 18.0 for all the scripts.