### PR TITLE
Add limits and requests

### DIFF
--- a/_infra/helm/uaa/values.yaml
+++ b/_infra/helm/uaa/values.yaml
@@ -25,7 +25,11 @@ service:
 
 resources:
   requests:
-    memory: "512Mi"
+    cpu: "400m"
+    memory: "1000Mi"
+  limits:
+    cpu: "1000m"
+    memory: "1200Mi"
 
 gcp:
   project: ras-rm-sandbox


### PR DESCRIPTION
# What and why?

The resource requests and limit weren't set up correctly in the helm chart.  After looking at the stats in dev, preprod and prod, these numbers feel like sensible defaults

# How to test?

# Trello
