### PR TITLE
External Secret Operator config w/ signed bot commits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ONSdigital/sdc-rmras

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,4 @@
 
 # How to test?
 
-# Trello
+# Jira

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,10 +69,29 @@ jobs:
           git fetch --tags
           echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
+      - name: Import BOT GPG key
+        run: echo $BOT_GPG_KEY | base64 --decode | gpg --batch --import
+        env:
+          BOT_GPG_KEY: ${{ secrets.BOT_GPG_KEY }}
+      - name: Prepare gpg CLI signing step
+        run: |
+          rm -rf /tmp/gpg.sh
+          echo '#!/bin/bash' >> /tmp/gpg.sh
+          echo 'gpg --batch --pinentry-mode=loopback --passphrase $BOT_GPG_KEY_PASSPHRASE $@' >> /tmp/gpg.sh
+          chmod +x /tmp/gpg.sh
+      - name: Setup git
+        run: |
+          git config commit.gpgsign true
+          git config user.signingkey "${{ secrets.BOT_GPG_KEY_ID }}"
+          git config gpg.program /tmp/gpg.sh
+          git config user.name "${{ secrets.BOT_USERNAME }}"
+          git config user.email "${{ secrets.BOT_EMAIL }}"
+
       - name: update versions
         if: github.ref != 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          BOT_GPG_KEY_PASSPHRASE: ${{ secrets.BOT_GPG_KEY_PASSPHRASE }}
           COMMIT_MSG: |
             auto patch increment
         shell: bash

--- a/_infra/helm/uaa/Chart.yaml
+++ b/_infra/helm/uaa/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.12
+version: 2.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.1.12
+appVersion: 2.1.13

--- a/_infra/helm/uaa/templates/externalsecrets.yaml
+++ b/_infra/helm/uaa/templates/externalsecrets.yaml
@@ -1,12 +1,15 @@
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: uaa-secret    # name of the k8s external secret and the k8s secret
+  name: uaa-secret
   namespace: {{ .Values.namespace }}
 spec:
-  backendType: gcpSecretsManager
-  projectId: {{ .Values.gcp.project }}
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gcp-secret-manager
+  refreshInterval: 1m
   data:
-    - key: uaa-secret     # name of the GCP secret
-      name: uaa.yml   # key name in the k8s secret
-      version: latest    # version of the GCP secret
+  - secretKey: uaa.yml
+    remoteRef:
+      key: uaa-secret
+      version: latest


### PR DESCRIPTION
# What and why?
Changing ExternalSecret to use the cluster secret store pattern to facilitate migration to the External Secrets Operator and to align with other ExternalSecrets, and also adding signed bot commits to the repo.

[See this PR for testing](https://github.com/ONSdigital/ras-rm-concourse/pull/218)
